### PR TITLE
Fix for SIPX-55

### DIFF
--- a/sipXyealink/etc/yealinkPhone/line-7X.properties
+++ b/sipXyealink/etc/yealinkPhone/line-7X.properties
@@ -1,7 +1,7 @@
 type.codecs_type.9\:G722=G.722 (HD Audio)
 type.codecs_type.8\:PCMA=G.711a
 type.codecs_type.18\:G729=G.729
-type.codecs_type.0\:PCMU=G.711µ
+type.codecs_type.0\:PCMU=G.711\u00B5
 type.codecs_type.4\:G723_53=G.723 5.3 KBit
 type.codecs_type.4\:G723_63=G.723 6.3 KBit
 type.codecs_type.112\:G726-16=G.726 16 KBit


### PR DESCRIPTION
Changed description text for G.711u.

Should now be displayed correctly.