### PR TITLE
Fix for SIPX-54 (doesn't use DSS Key)

### DIFF
--- a/sipXyealink/etc/yealinkPhone/config_v7x.vm
+++ b/sipXyealink/etc/yealinkPhone/config_v7x.vm
@@ -164,6 +164,47 @@ account.${L}.backup_outbound_port = 0
 #end
 #end
 
+# overwrite empty linekeys at beginning
+#set ($lastLineID = $lastLineID - 1)
+#foreach($L in [1..${lastLineID}])
+linekey.${L}.line = ${L}
+linekey.${L}.type = 15
+linekey.${L}.value = 
+#if ($L>$lastLineID)
+linekey.${L}.label = 
+#end
+linekey.${L}.pickup_value = 
+#end
+# add speeddials
+#set ($x = ${lastLineID} - 0)
+#foreach ($button in $cfg.SpeedDial)
+#set ($x = $x + 1)
+#if (!$button.Blf)
+#if (${x} < $phone.MaxDSSKeyCount)
+linekey.${x}.type = 13
+linekey.${x}.value = $button.Number
+linekey.${x}.label = $button.Label
+linekey.${x}.line = 1
+linekey.${x}.pickup_value = 
+#end
+#else
+linekey.${x}.type = 39
+linekey.${x}.line = 1
+linekey.${x}.value = 
+linekey.${x}.label = 
+linekey.${x}.pickup_value = 
+#end
+#end
+# Overwrite empty linekeys at end
+#set ($x = $x + 1)
+#foreach($L in [$x..$phone.MaxDSSKeyCount])
+linekey.${L}.line = 1
+linekey.${L}.type = 39
+linekey.${L}.value = 
+linekey.${L}.label = 
+linekey.${L}.pickup_value = 
+#end
+
 #Phone settings
 #phoneSetting($phone.Settings)
 


### PR DESCRIPTION
Fix for SIPX-54. Now it is possible to set SpeedDials by SIPX/OpenUC Web Interface. All DSS Key features are ignored. Currently I don't see if we really want then editable by user. Automatically created entries for BLF and speeddials overwrites them normaly.

Currently we've tested this with Yealink T46G and T48G.